### PR TITLE
Use sudo context when we are getting trackHitCount attribute

### DIFF
--- a/src/DeepLinkModule/javasource/deeplink/actions/ExecuteDeeplink.java
+++ b/src/DeepLinkModule/javasource/deeplink/actions/ExecuteDeeplink.java
@@ -122,10 +122,10 @@ public class ExecuteDeeplink extends CustomJavaAction<java.lang.Boolean>
 				Core.delete(this.getContext(), this.pendinglink.getMendixObject());
 			}
 
-			if(link.getTrackHitCount()) {
+			IContext sudoContext = getContext().createSudoClone();
+			if(link.getTrackHitCount(sudoContext)) {
 				//set hitcount (note, this might not be exact)
-				IContext sudoContext = getContext().createSudoClone();
-				link.setHitCount(sudoContext, link.getHitCount(getContext().createSudoClone()) + 1);
+				link.setHitCount(sudoContext, link.getHitCount(sudoContext) + 1);
 				Core.commit(sudoContext, link.getMendixObject());
 			}
 			return true;


### PR DESCRIPTION
At the moment we are trying to access `trackHitCount` with a regular `User`'s context. It's not allowed by the modules model. This MR changes the Java action code to always execute the getter within sudo context.